### PR TITLE
Support get value by batch for fast field in flatten manner

### DIFF
--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -141,15 +141,15 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
     /// values returned are flattened.
     pub fn values_for_docs_flatten(&self, doc_ids: &[DocId]) -> Vec<T>
     where T: Default {
-        let mut res = (0..doc_ids.len())
-            .into_iter()
-            .map(|_| T::default())
-            .collect::<Vec<_>>();
         let mut doc_ids_out = Vec::with_capacity(doc_ids.len());
         let mut row_ids = Vec::with_capacity(doc_ids.len());
         self.row_ids_for_docs(doc_ids, &mut doc_ids_out, &mut row_ids);
-        self.values.get_vals(&row_ids, &mut res);
-        res
+        let mut values = (0..row_ids.len())
+            .into_iter()
+            .map(|_| T::default())
+            .collect::<Vec<_>>();
+        self.values.get_vals(&row_ids, &mut values);
+        values
     }
 
     /// Get the docids of values which are in the provided value and docid range.

--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -136,6 +136,22 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
             .map(|value_row_id: RowId| self.values.get_val(value_row_id))
     }
 
+    /// Get batch of values for the provided docids.
+    /// Note: there may be multiple or no values for a specific doc_id, and the
+    /// values returned are flattened.
+    pub fn values_for_docs_flatten(&self, doc_ids: &[DocId]) -> Vec<T>
+    where T: Default {
+        let mut res = (0..doc_ids.len())
+            .into_iter()
+            .map(|_| T::default())
+            .collect::<Vec<_>>();
+        let mut doc_ids_out = Vec::with_capacity(doc_ids.len());
+        let mut row_ids = Vec::with_capacity(doc_ids.len());
+        self.row_ids_for_docs(doc_ids, &mut doc_ids_out, &mut row_ids);
+        self.values.get_vals(&row_ids, &mut res);
+        res
+    }
+
     /// Get the docids of values which are in the provided value and docid range.
     #[inline]
     pub fn get_docids_for_value_range(

--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -64,19 +64,23 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync + DowncastSync {
     /// May panic if `idx` is greater than the column length.
     fn get_vals(&self, indexes: &[u32], output: &mut [T]) {
         assert!(indexes.len() == output.len());
-        let out_and_idx_chunks = output.chunks_exact_mut(4).zip(indexes.chunks_exact(4));
-        for (out_x4, idx_x4) in out_and_idx_chunks {
-            out_x4[0] = self.get_val(idx_x4[0]);
-            out_x4[1] = self.get_val(idx_x4[1]);
-            out_x4[2] = self.get_val(idx_x4[2]);
-            out_x4[3] = self.get_val(idx_x4[3]);
+        let out_and_idx_chunks = output.chunks_exact_mut(8).zip(indexes.chunks_exact(8));
+        for (out_x8, idx_x8) in out_and_idx_chunks {
+            out_x8[0] = self.get_val(idx_x8[0]);
+            out_x8[1] = self.get_val(idx_x8[1]);
+            out_x8[2] = self.get_val(idx_x8[2]);
+            out_x8[3] = self.get_val(idx_x8[3]);
+            out_x8[4] = self.get_val(idx_x8[4]);
+            out_x8[5] = self.get_val(idx_x8[5]);
+            out_x8[6] = self.get_val(idx_x8[6]);
+            out_x8[7] = self.get_val(idx_x8[7]);
         }
 
         let out_and_idx_chunks = output
-            .chunks_exact_mut(4)
+            .chunks_exact_mut(8)
             .into_remainder()
             .iter_mut()
-            .zip(indexes.chunks_exact(4).remainder());
+            .zip(indexes.chunks_exact(8).remainder());
         for (out, idx) in out_and_idx_chunks {
             *out = self.get_val(*idx);
         }


### PR DESCRIPTION
As doc ids may have more than one or no values, the values returned for the batch of doc ids are flattened.