### PR TITLE
Ensure safe callback cleanup when dropping IndexReader (#10)

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -225,6 +225,11 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// `OnCommit` `ReloadPolicy`. Not implementing watch in a `Directory` only prevents the
     /// `OnCommit` `ReloadPolicy` to work properly.
     fn watch(&self, watch_callback: WatchCallback) -> crate::Result<WatchHandle>;
+
+    /// Stops the watcher and clears all registered callbacks.
+    /// The behavior of subsequent calls to `watch()` depends on the specific Directory
+    /// implementation.
+    fn unwatch_callbacks(&self);
 }
 
 /// DirectoryClone

--- a/src/directory/file_watcher.rs
+++ b/src/directory/file_watcher.rs
@@ -88,11 +88,15 @@ impl FileWatcher {
 
         Ok(hasher.finalize())
     }
+
+    pub fn graceful_stop(&self) {
+        self.state.store(2, Ordering::SeqCst);
+    }
 }
 
 impl Drop for FileWatcher {
     fn drop(&mut self) {
-        self.state.store(2, Ordering::SeqCst);
+        self.graceful_stop();
     }
 }
 

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -319,6 +319,10 @@ impl Directory for ManagedDirectory {
         self.directory.watch(watch_callback)
     }
 
+    fn unwatch_callbacks(&self) {
+        self.directory.unwatch_callbacks();
+    }
+
     fn sync_directory(&self) -> io::Result<()> {
         self.directory.sync_directory()?;
         Ok(())

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -503,6 +503,10 @@ impl Directory for MmapDirectory {
         Ok(self.inner.watch(watch_callback))
     }
 
+    fn unwatch_callbacks(&self) {
+        self.inner.watcher.graceful_stop();
+    }
+
     #[cfg(windows)]
     fn sync_directory(&self) -> Result<(), io::Error> {
         // On Windows, it is not necessary to fsync the parent directory to

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -240,6 +240,10 @@ impl Directory for RamDirectory {
         Ok(self.fs.write().unwrap().watch(watch_callback))
     }
 
+    fn unwatch_callbacks(&self) {
+        self.fs.write().unwrap().watch_router.clear();
+    }
+
     fn sync_directory(&self) -> io::Result<()> {
         Ok(())
     }

--- a/src/directory/watch_event_router.rs
+++ b/src/directory/watch_event_router.rs
@@ -26,6 +26,12 @@ pub struct WatchCallbackList {
     router: RwLock<Vec<Weak<WatchCallback>>>,
 }
 
+impl WatchCallbackList {
+    pub fn clear(&self) {
+        self.router.write().unwrap().clear();
+    }
+}
+
 /// Controls how long a directory should watch for a file change.
 ///
 /// After all the clones of `WatchHandle` are dropped, the associated will not be called when a

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -303,3 +303,11 @@ impl IndexReader {
         self.inner.searcher()
     }
 }
+
+impl Drop for IndexReader {
+    fn drop(&mut self) {
+        // For mmap directory, unwatch_callbacks() will block until running callbacks are finished
+        // to ensure no lock file will be created after the index reader is dropped.
+        self.inner.index.directory().unwatch_callbacks();
+    }
+}


### PR DESCRIPTION
### Issue
After the IndexReader is dropped, the FileWatcher may continue running. This can lead to lock files being generated in the directory, which may cause Milvus to fail when attempting to delete the directory

### Solution
Ensure FileWatcher stops running when IndexReader is dropped, preventing unnecessary lock file creation and avoiding deletion errors.

---------