### PR TITLE
Reduce initial memory usage of a single tantivy index

### DIFF
--- a/columnar/src/columnar/writer/mod.rs
+++ b/columnar/src/columnar/writer/mod.rs
@@ -46,7 +46,6 @@ struct SpareBuffers {
 /// let mut wrt: Vec<u8> =  Vec::new();
 /// columnar_writer.serialize(2u32, &mut wrt).unwrap();
 /// ```
-#[derive(Default)]
 pub struct ColumnarWriter {
     numerical_field_hash_map: ArenaHashMap,
     datetime_field_hash_map: ArenaHashMap,
@@ -60,7 +59,32 @@ pub struct ColumnarWriter {
     buffers: SpareBuffers,
 }
 
+impl Default for ColumnarWriter {
+    fn default() -> Self {
+        ColumnarWriter {
+            numerical_field_hash_map: ArenaHashMap::default(),
+            datetime_field_hash_map: ArenaHashMap::default(),
+            bool_field_hash_map: ArenaHashMap::default(),
+            ip_addr_field_hash_map: ArenaHashMap::default(),
+            bytes_field_hash_map: ArenaHashMap::default(),
+            str_field_hash_map: ArenaHashMap::default(),
+            arena: MemoryArena::default(),
+            dictionaries: Vec::new(),
+            buffers: SpareBuffers::default(),
+        }
+    }
+}
+
 impl ColumnarWriter {
+    /// Serialize an empty columnar (no columns) directly without allocating ArenaHashMaps.
+    /// This saves ~7MB memory compared to creating a default ColumnarWriter.
+    pub fn serialize_empty(num_docs: RowId, wrt: &mut dyn io::Write) -> io::Result<()> {
+        let mut serializer = ColumnarSerializer::new(wrt);
+        // No columns to serialize, just finalize with the format metadata
+        serializer.finalize(num_docs)?;
+        Ok(())
+    }
+
     pub fn mem_usage(&self) -> usize {
         self.arena.mem_usage()
             + self.numerical_field_hash_map.mem_usage()

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -15,7 +15,8 @@ const JSON_DEPTH_LIMIT: usize = 20;
 
 /// The `FastFieldsWriter` groups all of the fast field writers.
 pub struct FastFieldsWriter {
-    columnar_writer: ColumnarWriter,
+    /// Only created if schema has fast fields (memory optimization)
+    columnar_writer: Option<ColumnarWriter>,
     fast_field_names: Vec<Option<String>>, //< TODO see if we can hash the field name hash too.
     per_field_tokenizer: Vec<Option<TextAnalyzer>>,
     date_precisions: Vec<DateTimePrecision>,
@@ -37,7 +38,13 @@ impl FastFieldsWriter {
         schema: &Schema,
         tokenizer_manager: TokenizerManager,
     ) -> crate::Result<FastFieldsWriter> {
-        let mut columnar_writer = ColumnarWriter::default();
+        // Only create ColumnarWriter if there are fast fields (saves ~7MB memory)
+        let has_fast_fields = schema.fields().any(|(_, entry)| entry.field_type().is_fast());
+        let mut columnar_writer = if has_fast_fields {
+            Some(ColumnarWriter::default())
+        } else {
+            None
+        };
 
         let mut fast_field_names: Vec<Option<String>> = vec![None; schema.num_fields()];
         let mut date_precisions: Vec<DateTimePrecision> =
@@ -82,11 +89,13 @@ impl FastFieldsWriter {
 
             let sort_values_within_row = value_type == Type::Facet;
             if let Some(column_type) = value_type_to_column_type(value_type) {
-                columnar_writer.record_column_type(
-                    field_entry.name(),
-                    column_type,
-                    sort_values_within_row,
-                );
+                if let Some(ref mut writer) = columnar_writer {
+                    writer.record_column_type(
+                        field_entry.name(),
+                        column_type,
+                        sort_values_within_row,
+                    );
+                }
             }
         }
         Ok(FastFieldsWriter {
@@ -102,7 +111,7 @@ impl FastFieldsWriter {
 
     /// The memory used (inclusive childs)
     pub fn mem_usage(&self) -> usize {
-        self.columnar_writer.mem_usage()
+        self.columnar_writer.as_ref().map_or(0, |w| w.mem_usage())
     }
 
     /// Indexes all of the fastfields of a new document.
@@ -128,6 +137,12 @@ impl FastFieldsWriter {
             Some(name) => name,
         };
 
+        // If no columnar_writer, nothing to do (no fast fields in schema)
+        let columnar_writer = match &mut self.columnar_writer {
+            Some(w) => w,
+            None => return Ok(()),
+        };
+
         match value.as_value() {
             ReferenceValue::Leaf(leaf) => match leaf {
                 ReferenceValueLeaf::Null => {}
@@ -137,29 +152,29 @@ impl FastFieldsWriter {
                     {
                         let mut token_stream = tokenizer.token_stream(val);
                         token_stream.process(&mut |token: &Token| {
-                            self.columnar_writer
+                            columnar_writer
                                 .record_str(doc_id, field_name, &token.text);
                         })
                     } else {
-                        self.columnar_writer.record_str(doc_id, field_name, val);
+                        columnar_writer.record_str(doc_id, field_name, val);
                     }
                 }
                 ReferenceValueLeaf::U64(val) => {
-                    self.columnar_writer.record_numerical(
+                    columnar_writer.record_numerical(
                         doc_id,
                         field_name,
                         NumericalValue::from(val),
                     );
                 }
                 ReferenceValueLeaf::I64(val) => {
-                    self.columnar_writer.record_numerical(
+                    columnar_writer.record_numerical(
                         doc_id,
                         field_name,
                         NumericalValue::from(val),
                     );
                 }
                 ReferenceValueLeaf::F64(val) => {
-                    self.columnar_writer.record_numerical(
+                    columnar_writer.record_numerical(
                         doc_id,
                         field_name,
                         NumericalValue::from(val),
@@ -168,24 +183,24 @@ impl FastFieldsWriter {
                 ReferenceValueLeaf::Date(val) => {
                     let date_precision = self.date_precisions[field.field_id() as usize];
                     let truncated_datetime = val.truncate(date_precision);
-                    self.columnar_writer
+                    columnar_writer
                         .record_datetime(doc_id, field_name, truncated_datetime);
                 }
                 ReferenceValueLeaf::Facet(val) => {
-                    self.columnar_writer.record_str(doc_id, field_name, val);
+                    columnar_writer.record_str(doc_id, field_name, val);
                 }
                 ReferenceValueLeaf::Bytes(val) => {
-                    self.columnar_writer.record_bytes(doc_id, field_name, val);
+                    columnar_writer.record_bytes(doc_id, field_name, val);
                 }
                 ReferenceValueLeaf::IpAddr(val) => {
-                    self.columnar_writer.record_ip_addr(doc_id, field_name, val);
+                    columnar_writer.record_ip_addr(doc_id, field_name, val);
                 }
                 ReferenceValueLeaf::Bool(val) => {
-                    self.columnar_writer.record_bool(doc_id, field_name, val);
+                    columnar_writer.record_bool(doc_id, field_name, val);
                 }
                 ReferenceValueLeaf::PreTokStr(val) => {
                     for token in &val.tokens {
-                        self.columnar_writer
+                        columnar_writer
                             .record_str(doc_id, field_name, &token.text);
                     }
                 }
@@ -205,13 +220,14 @@ impl FastFieldsWriter {
                 self.json_path_buffer.set_expand_dots(expand_dots);
 
                 let text_analyzer = &mut self.per_field_tokenizer[field.field_id() as usize];
+                let columnar_writer = self.columnar_writer.as_mut().unwrap();
 
                 record_json_obj_to_columnar_writer::<V>(
                     doc_id,
                     val,
                     JSON_DEPTH_LIMIT,
                     &mut self.json_path_buffer,
-                    &mut self.columnar_writer,
+                    columnar_writer,
                     text_analyzer,
                 );
             }
@@ -224,7 +240,12 @@ impl FastFieldsWriter {
     /// order to the fast field serializer.
     pub fn serialize(mut self, wrt: &mut dyn io::Write) -> io::Result<()> {
         let num_docs = self.num_docs;
-        self.columnar_writer.serialize(num_docs, wrt)?;
+        if let Some(mut columnar_writer) = self.columnar_writer {
+            columnar_writer.serialize(num_docs, wrt)?;
+        } else {
+            // Write empty columnar format without allocating 7MB for ArenaHashMaps
+            ColumnarWriter::serialize_empty(num_docs, wrt)?;
+        }
         Ok(())
     }
 }

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -29,8 +29,8 @@ use crate::{FutureResult, Opstamp};
 // in the `memory_arena` goes below MARGIN_IN_BYTES.
 pub const MARGIN_IN_BYTES: usize = 1_000_000;
 
-// We impose the memory per thread to be at least 15 MB, as the baseline consumption is 12MB.
-pub const MEMORY_BUDGET_NUM_BYTES_MIN: usize = ((MARGIN_IN_BYTES as u32) * 15u32) as usize;
+// We impose the memory per thread to be at least 3 MB (baseline consumption is ~1.5MB with optimizations).
+pub const MEMORY_BUDGET_NUM_BYTES_MIN: usize = ((MARGIN_IN_BYTES as u32) * 3u32) as usize;
 pub const MEMORY_BUDGET_NUM_BYTES_MAX: usize = u32::MAX as usize - MARGIN_IN_BYTES;
 
 // We impose the number of index writer threads to be at most this.

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -6,6 +6,7 @@ use std::thread;
 use common::BitSet;
 use smallvec::{smallvec, SmallVec};
 
+use super::memory_config::MemoryProfile;
 use super::operation::{AddOperation, UserOperation};
 use super::pool::{get_tokio_indexing_worker_pool, init_pool};
 use super::segment_updater::SegmentUpdater;
@@ -36,11 +37,6 @@ pub const MEMORY_BUDGET_NUM_BYTES_MAX: usize = u32::MAX as usize - MARGIN_IN_BYT
 // We impose the number of index writer threads to be at most this.
 pub const MAX_NUM_THREAD: usize = 8;
 
-// Add document will block if the number of docs waiting in the queue to be indexed
-// reaches `PIPELINE_MAX_SIZE_IN_DOCS`
-// Reduced from 10_000 to 1000 to minimize memory footprint for single-threaded scenarios.
-const PIPELINE_MAX_SIZE_IN_DOCS: usize = 1_000;
-
 pub(crate) fn error_in_index_worker_thread(context: &str) -> TantivyError {
     TantivyError::ErrorInThread(format!(
         "{context}. A worker thread encountered an error (io::Error most likely) or panicked."
@@ -63,6 +59,10 @@ pub struct IndexWriterOptions {
     /// Defines the number of merger workers to use.
     // todo(SpadeA): we should use this to limit the running merge operations
     num_merge_worker: usize,
+    #[builder(default)]
+    /// Memory profile for tuning memory usage.
+    /// Use `LowMemory` for scenarios with many small indexes (e.g., growing segments).
+    pub memory_profile: MemoryProfile,
 }
 
 #[derive(Clone, bon::Builder)]
@@ -373,8 +373,9 @@ impl<D: Document> IndexWriter<D> {
         // Init thread pools
         init_pool(singleton_options.clone());
 
+        let pipeline_size = options.memory_profile.pipeline_max_size();
         let (document_sender, document_receiver): (AddBatchSender<D>, AddBatchReceiver<D>) =
-            async_channel::bounded(PIPELINE_MAX_SIZE_IN_DOCS);
+            async_channel::bounded(pipeline_size);
 
         let delete_queue = DeleteQueue::new();
 
@@ -626,8 +627,9 @@ impl<D: Document> IndexWriter<D> {
     ///
     /// Returns the former segment_ready channel.
     fn recreate_document_channel(&mut self) {
+        let pipeline_size = self.options.memory_profile.pipeline_max_size();
         let (document_sender, document_receiver): (AddBatchSender<D>, AddBatchReceiver<D>) =
-            async_channel::bounded(PIPELINE_MAX_SIZE_IN_DOCS);
+            async_channel::bounded(pipeline_size);
         self.operation_sender = Arc::new(document_sender);
         self.index_writer_status = IndexWriterStatus::from(document_receiver);
     }

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -38,7 +38,8 @@ pub const MAX_NUM_THREAD: usize = 8;
 
 // Add document will block if the number of docs waiting in the queue to be indexed
 // reaches `PIPELINE_MAX_SIZE_IN_DOCS`
-const PIPELINE_MAX_SIZE_IN_DOCS: usize = 10_000;
+// Reduced from 10_000 to 1000 to minimize memory footprint for single-threaded scenarios.
+const PIPELINE_MAX_SIZE_IN_DOCS: usize = 1_000;
 
 pub(crate) fn error_in_index_worker_thread(context: &str) -> TantivyError {
     TantivyError::ErrorInThread(format!(

--- a/src/indexer/memory_config.rs
+++ b/src/indexer/memory_config.rs
@@ -1,0 +1,56 @@
+/// Memory profile for IndexWriter configuration.
+///
+/// Different profiles optimize for different use cases:
+/// - `Default`: Standard configuration for high-throughput indexing
+/// - `LowMemory`: Optimized for scenarios with many small indexes (e.g., growing segments)
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MemoryProfile {
+    /// Standard configuration optimized for high-throughput indexing.
+    /// - Pipeline size: 10,000 documents
+    /// - Arena page size: 1MB
+    /// - Hash table max capacity: 2^19 (4MB)
+    /// - Min memory budget: 15MB
+    #[default]
+    Default,
+
+    /// Low memory configuration for scenarios with many small indexes.
+    /// - Pipeline size: 1,000 documents
+    /// - Arena page size: 256KB
+    /// - Hash table max capacity: 2^17 (1MB)
+    /// - Min memory budget: 3MB
+    LowMemory,
+}
+
+impl MemoryProfile {
+    /// Returns the maximum number of documents in the indexing pipeline.
+    pub fn pipeline_max_size(&self) -> usize {
+        match self {
+            Self::Default => 10_000,
+            Self::LowMemory => 1_000,
+        }
+    }
+
+    /// Returns the arena page size in bytes.
+    pub fn arena_page_size(&self) -> usize {
+        match self {
+            Self::Default => 1 << 20,  // 1MB
+            Self::LowMemory => 1 << 18, // 256KB
+        }
+    }
+
+    /// Returns the maximum power for hash table capacity (2^n).
+    pub fn hash_table_max_power(&self) -> usize {
+        match self {
+            Self::Default => 20,  // 2^19 max = 4MB
+            Self::LowMemory => 18, // 2^17 max = 1MB
+        }
+    }
+
+    /// Returns the minimum memory budget in bytes.
+    pub fn min_memory_budget(&self) -> usize {
+        match self {
+            Self::Default => 15 * 1024 * 1024,  // 15MB
+            Self::LowMemory => 3 * 1024 * 1024,  // 3MB
+        }
+    }
+}

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -5,6 +5,7 @@
 //! [`Index::writer`](crate::Index::writer).
 
 pub(crate) mod delete_queue;
+pub mod memory_config;
 pub(crate) mod path_to_unordered_id;
 
 pub(crate) mod doc_id_mapping;
@@ -31,8 +32,9 @@ mod stamper;
 
 use smallvec::SmallVec;
 
-pub use self::index_writer::{IndexWriter, IndexWriterOptions};
+pub use self::index_writer::{IndexWriter, IndexWriterOptions, SingletonIndexWriterOptions};
 pub use self::log_merge_policy::LogMergePolicy;
+pub use self::memory_config::MemoryProfile;
 pub use self::merge_operation::MergeOperation;
 pub use self::merge_policy::{MergeCandidate, MergePolicy, NoMergePolicy};
 use self::operation::AddOperation;

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -25,9 +25,7 @@ use crate::{DocId, Opstamp, TantivyError};
 /// Note this is a very dumb way to compute log2, but it is easier to proofread that way.
 fn compute_initial_table_size(per_thread_memory_budget: usize) -> crate::Result<usize> {
     let table_memory_upper_bound = per_thread_memory_budget / 3;
-    (10..20) // We cap it at 2^19 = 512K capacity.
-        // TODO: There are cases where this limit causes a
-        // reallocation in the hashmap. Check if this affects performance.
+    (10..18) // Cap at 2^17 = 128K capacity (1MB hash table)
         .map(|power| 1 << power)
         .take_while(|capacity| compute_table_memory_size(*capacity) < table_memory_upper_bound)
         .last()
@@ -99,19 +97,23 @@ impl SegmentWriter {
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
+        let ctx = IndexingContext::new(table_size);
+        let fast_field_writers = FastFieldsWriter::from_schema_and_tokenizer_manager(
+            &schema,
+            tokenizer_manager_fast_field,
+        )?;
+        let fieldnorms_writer = FieldNormsWriter::for_schema(&schema);
+        
         Ok(Self {
             num_docs: 0,
             max_doc: 0,
-            ctx: IndexingContext::new(table_size),
+            ctx,
             per_field_postings_writers,
-            fieldnorms_writer: FieldNormsWriter::for_schema(&schema),
+            fieldnorms_writer,
             json_path_writer: JsonPathWriter::default(),
             json_positions_per_path: IndexingPositionsPerPath::default(),
             segment_serializer,
-            fast_field_writers: FastFieldsWriter::from_schema_and_tokenizer_manager(
-                &schema,
-                tokenizer_manager_fast_field,
-            )?,
+            fast_field_writers,
             doc_opstamps: Vec::with_capacity(1_000),
             per_field_text_analyzers,
             term_buffer: Term::with_capacity(16),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@ pub use crate::index::{
     Index, IndexBuilder, IndexMeta, IndexSettings, InvertedIndexReader, Order, Segment,
     SegmentMeta, SegmentReader,
 };
-pub use crate::indexer::{IndexWriter, SingleSegmentIndexWriter};
+pub use crate::indexer::{IndexWriter, MemoryProfile, SingleSegmentIndexWriter};
 pub use crate::schema::{Document, TantivyDocument, Term};
 
 /// Index format version.

--- a/stacker/src/memory_arena.rs
+++ b/stacker/src/memory_arena.rs
@@ -24,8 +24,8 @@
 //! stores your object using `ptr::write_unaligned` and `ptr::read_unaligned`.
 use std::{mem, ptr};
 
-const NUM_BITS_PAGE_ADDR: usize = 20;
-const PAGE_SIZE: usize = 1 << NUM_BITS_PAGE_ADDR; // pages are 1 MB large
+const NUM_BITS_PAGE_ADDR: usize = 18;
+const PAGE_SIZE: usize = 1 << NUM_BITS_PAGE_ADDR; // pages are 256KB
 
 /// Represents a pointer into the `MemoryArena`
 /// .
@@ -106,7 +106,7 @@ impl MemoryArena {
     /// Returns an estimate in number of bytes
     /// of resident memory consumed by the `MemoryArena`.
     ///
-    /// Internally, it counts a number of `1MB` pages
+    /// Internally, it counts a number of pages
     /// and therefore delivers an upperbound.
     pub fn mem_usage(&self) -> usize {
         self.pages.len() * PAGE_SIZE
@@ -198,10 +198,10 @@ struct Page {
 impl Page {
     fn new(page_id: usize) -> Page {
         // We use 32-bits addresses.
-        // - 20 bits for the in-page addressing
-        // - 12 bits for the page id.
-        // This limits us to 2^12 - 1=4095 for the page id.
-        assert!(page_id < 4096);
+        // - 18 bits for the in-page addressing
+        // - 14 bits for the page id.
+        // This limits us to 2^14 - 1=16383 for the page id.
+        assert!(page_id < 16384);
         Page {
             page_id,
             len: 0,


### PR DESCRIPTION
* HashMap from term to posting list: init size reduced from 4MB to 1MB, initial capacity reduced from 512K entry to 128K
  * this holds the id of term and posting list, each entry is of 4 + 4 = 8 bytes
* 2 memory arenas holding the actual term and posting list: init size reduced from 1MB to 256KB
* A channel in IndexWriter managing concurrent writing: reduced from 10000 to 1000
* Made the ColumnWriter optional, and will not create it if the schema does not have any fast field.
